### PR TITLE
Add messages' functional routes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     'arrow-parens': 0,
     'comma-dangle': 0,
     'import/prefer-default-export': 0,
-    'no-unused-vars': ['error', { 'argsIgnorePattern': 'next' }],
+    'no-unused-vars': ['error', { argsIgnorePattern: 'next' }],
     'no-use-before-define': 0,
     'space-before-function-paren': 0,
     radix: 0,

--- a/insomnia/insomnia_messages_collection.json
+++ b/insomnia/insomnia_messages_collection.json
@@ -1,0 +1,253 @@
+{
+    "_type": "export",
+    "__export_format": 4,
+    "__export_date": "2022-11-13T12:36:29.274Z",
+    "__export_source": "insomnia.desktop.app:v2022.6.0",
+    "resources": [
+        {
+            "_id": "req_c39967b73b8447fb94e62df82c53dc38",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342926864,
+            "created": 1668342903685,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages/1",
+            "name": "editMessageText",
+            "description": "",
+            "method": "PATCH",
+            "body": {
+                "mimeType": "application/json",
+                "text": "{\n\t\"text\": \"¡Vivan las papas aliñaitas y la ensaladilla! 🤤\"\n}"
+            },
+            "parameters": [],
+            "headers": [
+                {
+                    "name": "Content-Type",
+                    "value": "application/json"
+                }
+            ],
+            "authentication": {},
+            "metaSortKey": -1668342903685,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "parentId": null,
+            "modified": 1668342566960,
+            "created": 1668342566960,
+            "name": "messages",
+            "description": "",
+            "scope": "collection",
+            "_type": "workspace"
+        },
+        {
+            "_id": "req_18ab8b08633c4efebcf5a81a9cb42079",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342951282,
+            "created": 1668342937700,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages/1234",
+            "name": "errorEditMessageText",
+            "description": "",
+            "method": "PATCH",
+            "body": {
+                "mimeType": "application/json",
+                "text": "{\n\t\"text\": \"¡Vivan las papas aliñaitas y la ensaladilla! 🤤\"\n}"
+            },
+            "parameters": [],
+            "headers": [
+                {
+                    "name": "Content-Type",
+                    "value": "application/json"
+                }
+            ],
+            "authentication": {},
+            "metaSortKey": -1668342869182.5,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "req_a33fde9f2959483db6f1dc0185df20e1",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342866826,
+            "created": 1668342834680,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages",
+            "name": "createNewMessage",
+            "description": "",
+            "method": "POST",
+            "body": {
+                "mimeType": "application/json",
+                "text": "{\n\t\"userId\": \"1\",\n\t\"roomId\": \"1\",\n\t\"text\": \"Me alegro mucho de que a ti también te gusten\",\n\t\"replyToId\": \"2\"\n}"
+            },
+            "parameters": [],
+            "headers": [
+                {
+                    "name": "Content-Type",
+                    "value": "application/json"
+                }
+            ],
+            "authentication": {},
+            "metaSortKey": -1668342834680,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "req_7d4344c6578b4cc39137fd4ce28ac190",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342893056,
+            "created": 1668342882569,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages",
+            "name": "errorCreateNewMessage",
+            "description": "",
+            "method": "POST",
+            "body": {
+                "mimeType": "application/json",
+                "text": "{\n\t\"roomId\": \"1\",\n\t\"text\": \"Me alegro mucho de que a ti también te gusten\",\n\t\"replyToId\": \"2\"\n}"
+            },
+            "parameters": [],
+            "headers": [
+                {
+                    "name": "Content-Type",
+                    "value": "application/json"
+                }
+            ],
+            "authentication": {},
+            "metaSortKey": -1668342808870.5,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "req_639dc9cc44554e058e310bdd7f087f63",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342827428,
+            "created": 1668342783061,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages/1234",
+            "name": "errorGetMessage",
+            "description": "",
+            "method": "GET",
+            "body": {},
+            "parameters": [],
+            "headers": [],
+            "authentication": {},
+            "metaSortKey": -1668342783061,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "req_3c40b1fe0e414ba5bf97dcba9024277b",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342777307,
+            "created": 1668342753553,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages/1",
+            "name": "getMessage",
+            "description": "",
+            "method": "GET",
+            "body": {},
+            "parameters": [],
+            "headers": [],
+            "authentication": {},
+            "metaSortKey": -1668342753553,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "req_8077e1cae8084f3ba6b567db6a3776ab",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342684820,
+            "created": 1668342672448,
+            "url": "{{ _.host }}{{ _.port }}/api/{{ _.apiVersion }}/messages",
+            "name": "getAllMessages",
+            "description": "",
+            "method": "GET",
+            "body": {},
+            "parameters": [],
+            "headers": [],
+            "authentication": {},
+            "metaSortKey": -1668342672448,
+            "isPrivate": false,
+            "settingStoreCookies": true,
+            "settingSendCookies": true,
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingRebuildPath": true,
+            "settingFollowRedirects": "global",
+            "_type": "request"
+        },
+        {
+            "_id": "env_08c5ec0d06861ee084f3a2bbe7a0ce16ea7ac604",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342732675,
+            "created": 1668342566986,
+            "name": "Base Environment",
+            "data": {
+                "host": "http://localhost",
+                "port": ":3001",
+                "apiVersion": "v1"
+            },
+            "dataPropertyOrder": {
+                "&": [
+                    "host",
+                    "port",
+                    "apiVersion"
+                ]
+            },
+            "color": null,
+            "isPrivate": false,
+            "metaSortKey": 1668342566986,
+            "_type": "environment"
+        },
+        {
+            "_id": "jar_08c5ec0d06861ee084f3a2bbe7a0ce16ea7ac604",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342566989,
+            "created": 1668342566989,
+            "name": "Default Jar",
+            "cookies": [],
+            "_type": "cookie_jar"
+        },
+        {
+            "_id": "spc_4cb6830ed95647b58627a21fec6caf97",
+            "parentId": "wrk_cdd45a6ebb3c4f5f9f509b655100904e",
+            "modified": 1668342566973,
+            "created": 1668342566973,
+            "fileName": "messages",
+            "contents": "",
+            "contentType": "yaml",
+            "_type": "api_spec"
+        }
+    ]
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
-import express from 'express';
-import compression from 'compression';
-import cookieParser from 'cookie-parser';
-import cors from 'cors';
-import helmet from 'helmet';
-import logger from 'morgan';
-import * as routes from './routes';
+const express = require('express');
+const compression = require('compression');
+const cookieParser = require('cookie-parser');
+const cors = require('cors');
+const helmet = require('helmet');
+const logger = require('morgan');
+const routes = require('./routes');
 
 const app = express();
 

--- a/server/bin/www.js
+++ b/server/bin/www.js
@@ -4,9 +4,9 @@
  * Module dependencies.
  */
 
-import debugPkg from 'debug';
-import http from 'http';
-import app from '../app';
+const debugPkg = require('debug');
+const http = require('http');
+const app = require('../app');
 
 const debug = debugPkg('js/www:server');
 

--- a/server/controllers/messagesController.js
+++ b/server/controllers/messagesController.js
@@ -1,3 +1,58 @@
-export const getAllMessages = (req, res, next) => {
-  res.json({ message: 'getAllMessages route' });
+import * as Message from '../models/Message';
+
+const getAllMessages = (req, res) => {
+  const messages = Message.getAll();
+
+  res.status(200).json({ data: messages });
+};
+
+const getMessage = (req, res) => {
+  const { id } = req.params;
+  const message = Message.getById(id);
+
+  if (!message) {
+    res.status(404).json({ data: [] });
+    return;
+  }
+
+  res.status(200).json({ data: message });
+};
+
+const createNewMessage = (req, res) => {
+  const {
+    userId, roomId, text, replyToId
+  } = req.body;
+
+  if (!userId || !roomId || !text) {
+    res.status(400).json({ data: {} });
+    return;
+  }
+
+  const message = Message.create(userId, roomId, text, replyToId);
+  res.status(201).json({ data: message });
+};
+
+const editMessageText = (req, res) => {
+  const { id } = req.params;
+  const { text } = req.body;
+
+  if (!id || !text) {
+    res.status(400).json({ data: {} });
+    return;
+  }
+
+  const messageEdited = Message.editText(id, text);
+  if (!messageEdited) {
+    res.status(404).json({ data: {} });
+    return;
+  }
+
+  res.status(201).json({ data: messageEdited });
+};
+
+module.exports = {
+  getAllMessages,
+  getMessage,
+  createNewMessage,
+  editMessageText
 };

--- a/server/controllers/messagesController.js
+++ b/server/controllers/messagesController.js
@@ -1,4 +1,4 @@
-import * as Message from '../models/Message';
+const Message = require('../models/Message');
 
 const getAllMessages = (req, res) => {
   const messages = Message.getAll();

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,0 +1,61 @@
+const messagesDb = [
+  {
+    id: '1',
+    userId: '1',
+    roomId: '1',
+    text: '¡Vivan las papas aliñaitas! 🤤',
+    replyToId: false
+  },
+  {
+    id: '2',
+    userId: '2',
+    roomId: '1',
+    text: '¡Di que si! 🥳',
+    replyToId: '1'
+  }
+];
+
+const getAll = () => messagesDb;
+
+const getById = (id) => {
+  const message = messagesDb.find(msg => msg.id === id);
+
+  if (!message) {
+    return null;
+  }
+
+  return message;
+};
+
+const create = (userId, roomId, text, replyToId) => {
+  const lastMessageId = parseInt(messagesDb[messagesDb.length - 1].id);
+
+  const newMessage = {
+    id: lastMessageId + 1, userId, roomId, text, replyToId
+  };
+
+  messagesDb.push(newMessage);
+
+  return newMessage;
+};
+
+const editText = (id, newText) => {
+  const messageIndex = messagesDb.findIndex(msg => msg.id === id);
+
+  if (messageIndex < 0) {
+    return null;
+  }
+
+  const message = messagesDb[messageIndex];
+  message.text = newText;
+  messagesDb[messageIndex] = message;
+
+  return message;
+};
+
+module.exports = {
+  getAll,
+  getById,
+  create,
+  editText
+};

--- a/server/routes/hello.js
+++ b/server/routes/hello.js
@@ -1,4 +1,4 @@
-import express from 'express';
+const express = require('express');
 
 const router = express.Router();
 

--- a/server/routes/hello.js
+++ b/server/routes/hello.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 /* GET home page. */
 router.get('/', (req, res) => {
-  res.json({ data: 'Hello from Chat\'s microservice' });
+  res.json({ data: 'Hello from Messages\' microservice' });
 });
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,2 +1,7 @@
-export { default as messages } from './messages';
-export { default as hello } from './hello';
+const hello = require('./hello').default;
+const messages = require('./messages').default;
+
+module.exports = {
+  hello,
+  messages
+};

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -3,7 +3,12 @@ import * as messagesController from '../controllers/messagesController';
 
 const router = express.Router();
 
-/* GET all users */
-router.get('/', messagesController.getAllMessages);
+router.route('/')
+  .get(messagesController.getAllMessages)
+  .post(messagesController.createNewMessage);
+
+router.route('/:id')
+  .get(messagesController.getMessage)
+  .patch(messagesController.editMessageText);
 
 export default router;

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import * as messagesController from '../controllers/messagesController';
+const express = require('express');
+const messagesController = require('../controllers/messagesController');
 
 const router = express.Router();
 


### PR DESCRIPTION
Routes related to messages' entity basic operations have been added to the service. These are the following ones:

- getAllMessages
- getMessage
- createNewMessage
- editMessageText

To achieve that I've developed an easy model class with an on-memory database. Also an Insomnia collection has been included in order to test those endpoints.