### PR TITLE
Complete almost all routes from messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://github.com/fisg4/ms-messages",
   "main": "dist/bin/www.js",
   "scripts": {
-    "start": "nodemon",
+    "start": "cross-env npm-run-all build server",
+    "develop": "nodemon",
     "build": "npm-run-all clean transpile",
     "server": "node ./dist/bin/www",
     "dev": "cross-env NODE_ENV=dev npm-run-all build server",
-    "prod": "cross-env NODE_ENV=prod npm-run-all build server",
     "clean": "rimraf dist",
     "transpile": "babel ./src --out-dir dist --copy-files",
     "lint": "eslint ./src",

--- a/postman/messages.postman_collection.json
+++ b/postman/messages.postman_collection.json
@@ -1,0 +1,187 @@
+{
+	"info": {
+		"_postman_id": "5fb04f4d-3e6d-4c4a-9726-ec1f2dd29c50",
+		"name": "messages",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "24780295"
+	},
+	"item": [
+		{
+			"name": "getAllMessagesFromRoom",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages?roomId=638ce6c15ee33401fd11f238",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages"
+					],
+					"query": [
+						{
+							"key": "roomId",
+							"value": "638ce6c15ee33401fd11f238"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "getMessage",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages/:id",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "6390c0e32b1a3b95309a7a89"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "createNewMessage",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"userId\": \"562b2649b2e70464f113c04d\",\n\t\"roomId\": \"562b2649b2e70464f113c16d\",\n\t\"text\": \"Me alegro mucho de que a ti también te gusten\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "editMessageText",
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"text\": \"¡Vivan las papas aliñaitas y la ensaladilla! 🤤\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages/:id",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "reportMessage",
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"userId\": \"637d127e156c8cf21ae8bd05\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages/:id/report",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages",
+						":id",
+						"report"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/postman/messages.postman_collection.json
+++ b/postman/messages.postman_collection.json
@@ -62,7 +62,7 @@
 					"variable": [
 						{
 							"key": "id",
-							"value": "6390c0e32b1a3b95309a7a89"
+							"value": "63923d2f001472d3363a1892"
 						}
 					]
 				}
@@ -86,7 +86,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"userId\": \"562b2649b2e70464f113c04d\",\n\t\"roomId\": \"562b2649b2e70464f113c16d\",\n\t\"text\": \"Me alegro mucho de que a ti también te gusten\"\n}"
+					"raw": "{\n\t\"roomId\": \"638ce6c15ee33401fd11f238\",\n\t\"text\": \"Me alegro mucho de que a ti también te gusten\"\n}"
 				},
 				"url": {
 					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages",
@@ -135,7 +135,7 @@
 					"variable": [
 						{
 							"key": "id",
-							"value": null
+							"value": "63923d2f001472d3363a1892"
 						}
 					]
 				}
@@ -176,7 +176,48 @@
 					"variable": [
 						{
 							"key": "id",
-							"value": null
+							"value": "639241403f4d0d5e5124b5b5"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "banMessage",
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "userId",
+						"value": "637d0c328a43d958f6ff661f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"userId\": \"637d127e156c8cf21ae8bd05\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/messages/:id/report",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"messages",
+						":id",
+						"report"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "639241403f4d0d5e5124b5b5"
 						}
 					]
 				}

--- a/postman/rooms.postman_collection.json
+++ b/postman/rooms.postman_collection.json
@@ -1,0 +1,149 @@
+{
+	"info": {
+		"_postman_id": "e24dd06f-b7a2-4bd0-afe5-6006daf31b5d",
+		"name": "rooms",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "24780295"
+	},
+	"item": [
+		{
+			"name": "getAllRooms",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/rooms",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"rooms"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "getRoom",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/rooms/:id",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"rooms",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "638ce6c15ee33401fd11f238"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "deleteRoom",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/rooms/:id",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"rooms",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "638ce7d350c1f8f9a9fbe8fc"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "modifyRoomParticipants",
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "",
+						"value": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"participants\": [\n        \"637d0c328a43d958f6ff661f\",\n        \"637d0c328a43d958f6ff661d\"\n    ]\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/rooms/:id",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"rooms",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "638ce6c15ee33401fd11f238"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "createRoom",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"name\": \"To delete\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}{{port}}/api/{{apiVersion}}/rooms/",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"{{apiVersion}}",
+						"rooms",
+						""
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/controllers/messagesController.js
+++ b/src/controllers/messagesController.js
@@ -1,13 +1,39 @@
-const { Message } = require('../models');
+const { Message, Room } = require('../models');
 
-// TODO: Append message and status to responses
+const getAllMessagesFromRoom = async (req, res) => {
+  // TODO: Modify this when we support authentication and move to middleware
+  const { userId } = req.header.auth;
+  if (!userId) {
+    res.status(400).json({
+      success: false,
+      message: 'User is not authenticated',
+      content: []
+    });
+    return;
+  }
 
-// possibily this could be removed
-const getAllMessages = async (req, res) => {
-  const { page = 0, size = 10 } = req.query;
+  const { roomId, page = 0, size = 10 } = req.query;
+  if (!roomId) {
+    res.status(400).json({
+      success: false,
+      message: 'Selecting a room is mandatory',
+      content: []
+    });
+    return;
+  }
 
   try {
-    const messages = await Message.getAll(page, size);
+    const room = await Room.findById(roomId);
+    if (!room || room.checkUserIsParticipant(userId)) {
+      res.status(403).json({
+        success: false,
+        message: `Logged user is not a participant of the room with id ${roomId}`,
+        content: []
+      });
+      return;
+    }
+
+    const messages = await Message.getAllFromRoomId(roomId, page, size);
     res.status(200).json({
       success: true,
       message: 'OK',
@@ -52,11 +78,31 @@ const getMessage = async (req, res) => {
 };
 
 const createNewMessage = async (req, res) => {
+  // TODO: Modify this when we support authentication and move to middleware
+  const { userId } = req.header.auth;
+  if (!userId) {
+    res.status(400).json({
+      success: false,
+      message: 'User is not authenticated',
+      content: []
+    });
+    return;
+  }
+
   const {
-    userId, roomId, text, replyToId = null
+    roomId, text, replyToId = null
   } = req.body;
 
   try {
+    const room = await Room.findById(roomId);
+    if (!room || room.checkUserIsParticipant(userId)) {
+      res.status(403).json({
+        success: false,
+        message: `Logged user is not a participant of the room with id '${roomId}'`,
+        content: []
+      });
+      return;
+    }
     const newMessage = await Message.insert(userId, roomId, text, replyToId);
     res.status(201).json({
       success: true,
@@ -81,6 +127,17 @@ const createNewMessage = async (req, res) => {
 };
 
 const editMessageText = async (req, res) => {
+  // TODO: Modify this when we support authentication and move to middleware
+  const { userId } = req.header.auth;
+  if (!userId) {
+    res.status(400).json({
+      success: false,
+      message: 'User is not authenticated',
+      content: []
+    });
+    return;
+  }
+
   const { id } = req.params;
   const { text } = req.body;
 
@@ -90,6 +147,15 @@ const editMessageText = async (req, res) => {
       res.status(404).json({
         success: false,
         message: `Message with id '${id}' not found`,
+        content: {}
+      });
+      return;
+    }
+
+    if (message.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: `Logged user is not the author of the message with id '${id}'`,
         content: {}
       });
       return;
@@ -113,7 +179,7 @@ const editMessageText = async (req, res) => {
 
     res.status(500).json({
       success: false,
-      message: `Error updating the text of message with id '${id}' and text '${text}'`,
+      message: `Error updating the message with id '${id}' and the new text '${text}'`,
       content: {}
     });
   }
@@ -121,13 +187,14 @@ const editMessageText = async (req, res) => {
 
 const reportMessage = async (req, res) => {
   const { id } = req.params;
-  const { userId } = req.body;
 
+  // TODO: Modify this when we support authentication and move to middleware
+  const { userId } = req.header.auth;
   if (!userId) {
     res.status(400).json({
       success: false,
-      message: 'It is necessary to set an userId',
-      content: {}
+      message: 'User is not authenticated',
+      content: []
     });
     return;
   }
@@ -176,12 +243,49 @@ const reportMessage = async (req, res) => {
   }
 };
 
-// TODO: implement function to update report
+const banMessage = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const message = await Message.getById(id);
+    if (!message) {
+      res.status(404).json({
+        success: false,
+        message: `Message with id '${id}' not found`,
+        content: {}
+      });
+      return;
+    }
+
+    const bannedMessage = await message.ban();
+
+    res.status(201).json({
+      success: true,
+      message: 'OK',
+      content: bannedMessage
+    });
+  } catch (err) {
+    if (err.errors) {
+      res.status(400).json({
+        success: false,
+        message: err.message,
+        content: {}
+      });
+    }
+
+    res.status(500).json({
+      success: false,
+      message: `Error when banning the message with id '${id}'`,
+      content: {}
+    });
+  }
+};
 
 module.exports = {
-  getAllMessages,
+  getAllMessagesFromRoom,
   getMessage,
   createNewMessage,
   editMessageText,
-  reportMessage
+  reportMessage,
+  banMessage
 };

--- a/src/controllers/messagesController.js
+++ b/src/controllers/messagesController.js
@@ -1,8 +1,9 @@
 const { Message, Room } = require('../models');
 
+// TODO: This function must return typical pagination values (ie. total, numPages)
 const getAllMessagesFromRoom = async (req, res) => {
   // TODO: Modify this when we support authentication and move to middleware
-  const { userId } = req.header.auth;
+  const userId = req.header('userId');
   if (!userId) {
     res.status(400).json({
       success: false,
@@ -24,10 +25,18 @@ const getAllMessagesFromRoom = async (req, res) => {
 
   try {
     const room = await Room.findById(roomId);
-    if (!room || room.checkUserIsParticipant(userId)) {
+    if (!room) {
+      res.status(404).json({
+        success: false,
+        message: `Room with id '${roomId}' not found`,
+        content: []
+      });
+      return;
+    }
+    if (!room.checkUserIsParticipant(userId)) {
       res.status(403).json({
         success: false,
-        message: `Logged user is not a participant of the room with id ${roomId}`,
+        message: `Logged user is not a participant of the room with id '${roomId}'`,
         content: []
       });
       return;
@@ -53,7 +62,6 @@ const getMessage = async (req, res) => {
 
   try {
     const message = await Message.getById(id);
-
     if (!message) {
       res.status(404).json({
         success: false,
@@ -79,7 +87,7 @@ const getMessage = async (req, res) => {
 
 const createNewMessage = async (req, res) => {
   // TODO: Modify this when we support authentication and move to middleware
-  const { userId } = req.header.auth;
+  const userId = req.header('userId');
   if (!userId) {
     res.status(400).json({
       success: false,
@@ -95,7 +103,15 @@ const createNewMessage = async (req, res) => {
 
   try {
     const room = await Room.findById(roomId);
-    if (!room || room.checkUserIsParticipant(userId)) {
+    if (!room) {
+      res.status(404).json({
+        success: false,
+        message: `Room with id '${roomId}' not found`,
+        content: []
+      });
+      return;
+    }
+    if (!room.checkUserIsParticipant(userId)) {
       res.status(403).json({
         success: false,
         message: `Logged user is not a participant of the room with id '${roomId}'`,
@@ -103,6 +119,7 @@ const createNewMessage = async (req, res) => {
       });
       return;
     }
+
     const newMessage = await Message.insert(userId, roomId, text, replyToId);
     res.status(201).json({
       success: true,
@@ -128,7 +145,7 @@ const createNewMessage = async (req, res) => {
 
 const editMessageText = async (req, res) => {
   // TODO: Modify this when we support authentication and move to middleware
-  const { userId } = req.header.auth;
+  const userId = req.header('userId');
   if (!userId) {
     res.status(400).json({
       success: false,
@@ -189,7 +206,7 @@ const reportMessage = async (req, res) => {
   const { id } = req.params;
 
   // TODO: Modify this when we support authentication and move to middleware
-  const { userId } = req.header.auth;
+  const userId = req.header('userId');
   if (!userId) {
     res.status(400).json({
       success: false,

--- a/src/db.js
+++ b/src/db.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const mongoose = require('mongoose');
 
 const ENV = process.env.NODE_ENV || 'dev';

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -16,7 +16,7 @@ const messageSchema = new Schema({
 
 messageSchema.statics.getAll = (page = 0, size = 10) => mongoose.model('Message').find({ limit: size, skip: page * size });
 
-messageSchema.statics.getAllFromRoomId = (roomId, page = 0, limit = 10) => mongoose.model('Message').find({ roomId }, { limit, skip: limit * page });
+messageSchema.statics.getAllFromRoomId = (roomId, page = 0, limit = 10) => mongoose.model('Message').find({ roomId }).skip(limit * page).limit(limit);
 
 messageSchema.statics.getById = (id) => mongoose.model('Message').findById(id);
 

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -12,8 +12,6 @@ const messageSchema = new Schema({
   }
 }, { timestamps: true });
 
-// TODO: Improve error handling (validations)
-
 // static methods
 
 messageSchema.statics.getAll = (page = 0, size = 10) => mongoose.model('Message').find({ limit: size, skip: page * size });
@@ -44,6 +42,9 @@ messageSchema.methods.report = function report(userId) {
   return this.save();
 };
 
-// TODO: implement method to update report
+messageSchema.methods.ban = function ban() {
+  this.reportedBy.isBanned = true;
+  return this.save();
+};
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -16,7 +16,22 @@ const messageSchema = new Schema({
 
 messageSchema.statics.getAll = (page = 0, size = 10) => mongoose.model('Message').find({ limit: size, skip: page * size });
 
-messageSchema.statics.getAllFromRoomId = (roomId, page = 0, limit = 10) => mongoose.model('Message').find({ roomId }).skip(limit * page).limit(limit);
+messageSchema.statics.getAllFromRoomId = async (roomId, page = 0, limit = 10) => {
+  const count = await mongoose.model('Message').find({ roomId }).count();
+  if (count === 0) {
+    return {
+      content: [], totalElements: 0, totalPages: 0, currentPage: 0
+    };
+  }
+
+  const messages = await mongoose.model('Message').find({ roomId }).skip(limit * page).limit(limit);
+  return {
+    content: messages,
+    totalElements: count,
+    totalPages: Math.ceil(count / limit),
+    currentPage: page
+  };
+};
 
 messageSchema.statics.getById = (id) => mongoose.model('Message').findById(id);
 

--- a/src/models/Room.js
+++ b/src/models/Room.js
@@ -14,4 +14,8 @@ const roomSchema = new Schema(
   }
 );
 
+roomSchema.methods.checkUserIsParticipant = function checkUserIsParticipant(userId) {
+  return this.participants.indexOf(userId) !== -1;
+};
+
 module.exports = mongoose.model('Room', roomSchema);

--- a/src/routes/messages.js
+++ b/src/routes/messages.js
@@ -4,7 +4,7 @@ const messagesController = require('../controllers/messagesController');
 const router = express.Router();
 
 router.route('/')
-  .get(messagesController.getAllMessages)
+  .get(messagesController.getAllMessagesFromRoom)
   .post(messagesController.createNewMessage);
 
 router.route('/:id')
@@ -14,6 +14,7 @@ router.route('/:id')
 router.route('/:id/report')
   .patch(messagesController.reportMessage);
 
-// TODO: implement route to update report (maybe /:id/ban)
+router.route('/:id/ban')
+  .patch(messagesController.banMessage);
 
 export default router;


### PR DESCRIPTION
With this PR I've completed almost all routes from messages entity, only translation of the message text (external service) and integration with support microservice are left. To be more specific, those are the main changes to the code:

- Modify package.json scripts so the deployment gets correctly the node_env variable
- Translate Insomnia exports to postman
- Create the scaffolding for user authentication
- Update the route for getting all messages: allow to take all exclusively from a determined room and paginate the results
- Include the /ban route
- Implement some business logic and restrictions in the controller