### PR TITLE
Fix support integration after auth inclusion

### DIFF
--- a/src/controllers/messagesController.js
+++ b/src/controllers/messagesController.js
@@ -128,7 +128,7 @@ const reportMessage = async (req, res) => {
     }
 
     const reportedMessage = await message.report(userId, reason);
-    const reportSent = await supportService.sendReport(userId, reportedMessage.id, reason);
+    const reportSent = await supportService.sendReport(token, reportedMessage.id, reason);
     if (!reportSent) {
       // Rollback the operation
       const previousMessage = await message.removeReport();

--- a/src/services/supportService.js
+++ b/src/services/supportService.js
@@ -1,11 +1,14 @@
 const urlJoin = require('url-join');
 const axios = require('axios');
+const { decodeToken } = require('../auth/jwt');
 
 const HOST = process.env.SUPPORT_HOST || 'http://localhost:3002';
 const ENDPOINT = '/support/v1';
 const ROUTE = '/reports';
 
-const sendReport = async (authorId, messageId, reason) => {
+const sendReport = async (token, messageId, reason) => {
+  const authorId = decodeToken(token).id;
+
   const url = urlJoin(HOST, ENDPOINT, ROUTE);
   const body = {
     authorId,
@@ -13,9 +16,13 @@ const sendReport = async (authorId, messageId, reason) => {
     title: `Report of message ${messageId}`,
     text: reason
   };
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: token
+  };
 
   try {
-    const response = await axios.post(url, body);
+    const response = await axios.post(url, body, { headers });
     return response.status === 201;
   } catch (err) {
     return false;

--- a/tests/controllers/messages.test.js
+++ b/tests/controllers/messages.test.js
@@ -174,7 +174,7 @@ describe('Test messages API', () => {
     const reason = 'reason test';
     const userId = '637d0c328a43d958f6ff661f';
 
-    const token = jwt.generateToken({ id: userId });
+    const token = jwt.generateToken({ id: userId, role: 'user' });
 
     let getMessageByIdMock;
     let getRoomByIdMock;
@@ -205,7 +205,7 @@ describe('Test messages API', () => {
       getRoomByIdMock.mockImplementation(async (roomId) => Promise.resolve(room));
       reportMock.mockImplementation(async (userId, reason) => Promise.resolve(reportedMessage));
       checkUserIsParticipantMock.mockImplementation((userId) => true);
-      sendReportMock.mockImplementation(async (userId, messageId, reason) => Promise.resolve(true));
+      sendReportMock.mockImplementation(async (token, messageId, reason) => Promise.resolve(true));
       removeReportMock.mockImplementation(async () => Promise.resolve(message));
 
       return request(app)


### PR DESCRIPTION
After support team added authorization restrictions to their mS, the integration we made was not working properly. That's why I've modified the support service included in our mS; it sends the token now to enable auth.